### PR TITLE
Parallelize KPD

### DIFF
--- a/jetnet/__init__.py
+++ b/jetnet/__init__.py
@@ -1,7 +1,5 @@
 # __init__
 
-# IMPORTANT: evaluation has to be imported first since energyflow must be imported before torch
-# See https://github.com/pkomiske/EnergyFlow/issues/24
 import jetnet.datasets  # noqa: F401
 import jetnet.datasets.normalisations
 import jetnet.datasets.utils
@@ -9,4 +7,4 @@ import jetnet.evaluation
 import jetnet.losses
 import jetnet.utils  # noqa: F401
 
-__version__ = "0.2.3.post1"
+__version__ = "0.2.3.post2"

--- a/tests/evaluation/test_gen_metrics.py
+++ b/tests/evaluation/test_gen_metrics.py
@@ -18,6 +18,7 @@ def test_fpd():
     assert err < 1e-3
 
 
-def test_kpd():
-    assert evaluation.kpd(test_zeros, test_zeros) == approx([0, 0])
-    assert evaluation.kpd(test_zeros, test_ones) == approx([15, 0])
+@pytest.mark.parametrize("num_threads", [None, 0, 2])  # test numba parallelization
+def test_kpd(num_threads):
+    assert evaluation.kpd(test_zeros, test_zeros, num_threads=num_threads) == approx([0, 0])
+    assert evaluation.kpd(test_zeros, test_ones, num_threads=num_threads) == approx([15, 0])


### PR DESCRIPTION
Add the `num_threads` option to `evaluation.kpd` to allow parallelizing KPD through `numba`.