### PR TITLE
Fix large imaginary component in FPD issue

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,4 +57,4 @@ jobs:
           if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
       - name: Test with pytest
         run: |
-          pytest -n 0 --duration 0 -v -m "not slow" -k ${{ matrix.pytest-file }}
+          pytest -n 0 --durations 0 -v -m "not slow" -k ${{ matrix.pytest-file }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,8 @@ jobs:
           black: true
           black_auto_fix: true
 
+  # TODO: might want to consider running tests only for changed files at some point https://github.com/marketplace/actions/changed-files
+
   pytest:
     runs-on: ubuntu-latest
 
@@ -55,4 +57,4 @@ jobs:
           if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
       - name: Test with pytest
         run: |
-          pytest -n 0 -v -m "not slow" -k ${{ matrix.pytest-file }}
+          pytest -n 0 --duration 0 -v -m "not slow" -k ${{ matrix.pytest-file }}

--- a/jetnet/evaluation/gen_metrics.py
+++ b/jetnet/evaluation/gen_metrics.py
@@ -86,9 +86,20 @@ def _calculate_frechet_distance(mu1, sigma1, mu2, sigma2, eps=1e-6):
 
     # Numerical error might give slight imaginary component
     if np.iscomplexobj(covmean):
-        if not np.allclose(np.diagonal(covmean).imag, 0, atol=1e-3):
-            m = np.max(np.abs(covmean.imag))
-            raise ValueError("Imaginary component {}".format(m))
+        if not (
+            np.allclose(np.diagonal(covmean).imag, 0, atol=1e-3)
+            or np.isclose(np.trace(covmean.imag) / np.trace(covmean.real), 0, atol=1e-3)
+        ):
+            im_trace = np.trace(covmean.imag)
+            re_trace = np.trace(covmean.real)
+            warnings.warn(
+                (
+                    "Large imaginary components in covariance matrix while calculating "
+                    f"Fréchet distance Im: {im_trace:.2f} Re: {re_trace:.2f}"
+                ),
+                RuntimeWarning,
+            )
+
         covmean = covmean.real
 
     tr_covmean = np.trace(covmean)

--- a/tests/evaluation/test_gen_metrics.py
+++ b/tests/evaluation/test_gen_metrics.py
@@ -18,7 +18,7 @@ def test_fpd():
     assert err < 1e-3
 
 
-@pytest.mark.parametrize("num_threads", [None, 0, 2])  # test numba parallelization
+@pytest.mark.parametrize("num_threads", [None, 2])  # test numba parallelization
 def test_kpd(num_threads):
     assert evaluation.kpd(test_zeros, test_zeros, num_threads=num_threads) == approx([0, 0])
     assert evaluation.kpd(test_zeros, test_ones, num_threads=num_threads) == approx([15, 0])


### PR DESCRIPTION
Resolves edge case where an error would be raised if the absolute imaginary component in the covariance matrix for the Fréchet distance calculation was too large (could happen if the real components are very large).

Now checks the imaginary component _relative_ to the real component as well, and raises a warning instead of an error.