### PR TITLE
Fix tests in Python 3.11

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,4 +57,4 @@ jobs:
           if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
       - name: Test with pytest
         run: |
-          pytest -n 0 --durations 0 -v -m "not slow" -k ${{ matrix.pytest-file }}
+          pytest -n 0 --durations 0 -v -m "not slow" ${{ matrix.pytest-file }}

--- a/jetnet/datasets/normalisations.py
+++ b/jetnet/datasets/normalisations.py
@@ -1,6 +1,7 @@
 """
 Suite of common ways to normalise data.
 """
+
 from __future__ import annotations
 
 from abc import ABC, abstractmethod

--- a/jetnet/datasets/utils.py
+++ b/jetnet/datasets/utils.py
@@ -1,6 +1,7 @@
 """
 Utility methods for datasets.
 """
+
 from __future__ import annotations
 
 import hashlib


### PR DESCRIPTION
The `pytest -k` arg appears to be causing errors in Python 3.11 and pytest 8.0.0, e.g. https://github.com/jet-net/JetNet/actions/runs/7700831393/job/21118780687?pr=66, so this removes the arg.